### PR TITLE
Add Disney+ description for Heavenly Delusions S01E01 Heaven and Hell

### DIFF
--- a/transcripts/disney/Heavenly Delusions/S01E01 - Heaven and Hell.json
+++ b/transcripts/disney/Heavenly Delusions/S01E01 - Heaven and Hell.json
@@ -1,0 +1,318 @@
+{
+  "metadata": {
+    "episode": 1,
+    "season": 1,
+    "seriesTitle": "Heavenly Delusions",
+    "title": "Heaven and Hell",
+    "type": "episode"
+  },
+  "scripts": [
+    {
+      "author": "Julianna Mealin",
+      "language": "en-US",
+      "tracks": [
+        {
+          "text": "Dew glistens on ripe tomatoes. Students run across green grass onto stepping stones crossing clear water. Children laugh while watering tomatoes. A black haired girl runs up to a window, where a boy lies inside in a bed.",
+          "timestamp": 2
+        },
+        {
+          "text": "A boy sits in the grass and sketches. Children play on the lawn in front of a multi-story white building. Above them, a girl stands alone on the second floor. She stares up at the glowing hexagons of the facility roof. A blond girl approaches her.",
+          "timestamp": 17.2
+        },
+        {
+          "text": "Mimihime turns and walks past the girl",
+          "timestamp": 36
+        },
+        {
+          "text": "The robot teacher gestures, and the test appears on the 5 students' tablets.",
+          "timestamp": 61
+        },
+        {
+          "text": "Outside, Kuku watches the sandy-haired boy sketch a fish with 4 pairs of hands.",
+          "timestamp": 65
+        },
+        {
+          "text": "In the classroom, the blond girl looks at her tablet. It glitches, and a question appears. 11. Do you want to go outside of the outside? Yes No. The girl's eyes grow wide.",
+          "timestamp": 97
+        },
+        {
+          "text": "A blond boy kicks a rock along asphalt, cracked and overgrown with weeds. He walks with a brown haired girl wearing a white jacket. We zoom out away from them, past the rusted guard rails and broken, rusted cards on the cracked and overgrown highway hugging the mountain, blanketed in forest, dotted with remnants of metal and concrete",
+          "timestamp": 114
+        },
+        {
+          "text": "Cracked white text reads, Tengoku Daimakyo, spelled Heaven + Land, Large + Demon + Domain.",
+          "timestamp": 128
+        },
+        {
+          "text": "Crows gather on the roof of a building with fraying power lines. Greenery grows over collapsed houses. A truck sits abandoned, its windows shattered. A rusted stop stands at an angle, dim, in front of an overgrown and crumbling apartment complex.",
+          "timestamp": 137
+        },
+        {
+          "text": "The blond boy points",
+          "timestamp": 158
+        },
+        {
+          "text": "A cinder block flies through the glass, past a box labelled Cerulean. A low table lies broken in a traditional-style Japanese house.",
+          "timestamp": 176
+        },
+        {
+          "text": "A drawer sits open with paint tubes and a packaged toothbrush.",
+          "timestamp": 186
+        },
+        {
+          "text": "Weeds grow out of the bowl of a toilet. She pulls them and sits down.",
+          "timestamp": 199
+        },
+        {
+          "text": "They climb stairs. Above them, the sky can be seen between bowing rafters.",
+          "timestamp": 216
+        },
+        {
+          "text": "Sis stops",
+          "timestamp": 231
+        },
+        {
+          "text": "Maru watches as she walks into the room. A desiccated hand hangs off the bed, wearing a ring. Sis approaches, taking in the pale clothes against the dark, wrinkled skin of the pair of corpses, holding hands in death.",
+          "timestamp": 234
+        },
+        {
+          "text": "Smoke rises from a balcony. Sis chops greens. Inside, an ivory tusk is mounted under a devil's mask. A sign reads Yakuza NawaShiro Group.",
+          "timestamp": 258
+        },
+        {
+          "text": "Rain patters on a skylight. Maru lies in a sleeping bag on a couch. By the light of a camping lantern, Sis holds up photographs in a plastic bag. One depicts a 20-something man with short black hair. Another depicts a 40-something man with silver hair and a scar across his forehead.",
+          "timestamp": 317
+        },
+        {
+          "text": "He rolls over. She smiles softly.",
+          "timestamp": 348
+        },
+        {
+          "text": "Maru stares at the couch back. Sis turns off the lantern.",
+          "timestamp": 369
+        },
+        {
+          "text": "Descending down from dark and stormy clouds, flying over mountains and valleys, a large, black bird monster flies through the night. It has a long, trunk-like tube for a head, and glistening strands of silver float around it. Purple lightning strikes behind the monster as it lands on the roof of a hotel, the way a crow might land on a mailbox.",
+          "timestamp": 375
+        },
+        {
+          "text": "It spreads its wings and screams.",
+          "timestamp": 391.1
+        },
+        {
+          "text": "She raises a hand. 3 scruffy looking men emerge from behind a car and block their path. Behind them, 2 figures hop over a fence from an alley.",
+          "timestamp": 450
+        },
+        {
+          "text": "Sis pulls a gun from a holster.",
+          "timestamp": 474
+        },
+        {
+          "text": "Bandit studies the gun with binoculars.",
+          "timestamp": 502.5
+        },
+        {
+          "text": "Sis narrows her eyes and lowers the gun",
+          "timestamp": 507
+        },
+        {
+          "text": "She smirks.",
+          "timestamp": 521
+        },
+        {
+          "text": "Sis runs and jumps onto a fence. Maru puts his back to her. He minimally sidesteps a bandit swinging a pipe. He ducks a knife, then dodges more stabs. He steps in and starts to throw the bandit. Pipe Bandit swings, and Knife Bandit escapes the throw.",
+          "timestamp": 527
+        },
+        {
+          "text": "Maru spins away from Knife Bandit and kicks him back. Pipe Bandit swings, maru ducks and kicks. Pipe Bandit recovers and swings. Maru parkours off fence, kicks him in the face, lands, and kicks again. Pipe Bandit spins to the ground.",
+          "timestamp": 534
+        },
+        {
+          "text": "Golf club bandit runs forward. From her perch on the chain link fence, Sis aims her gun and fires. A crackling beam of energy fires across the path to a light pole, forming an orange and red molten crater in the center. The bandits stop. The pole falls, power lines snapping from the force, and crashes between the teens and bandits, crushing a section of fence.",
+          "timestamp": 542
+        },
+        {
+          "text": "Sis approaches Cleaver Bandit.",
+          "timestamp": 560
+        },
+        {
+          "text": "A sign over broken windows reads MoriYama Hospital.",
+          "timestamp": 574.9
+        },
+        {
+          "text": "Pill packs, darkness",
+          "timestamp": 584
+        },
+        {
+          "text": "Club Bandit glances at the battery pack",
+          "timestamp": 619
+        },
+        {
+          "text": "Knife bandit lays a map on a table. Sis walks over and leans over as bandit points. Time passes.",
+          "timestamp": 661
+        },
+        {
+          "text": "She slides the blue and yellow battery into the butt of the gun.",
+          "timestamp": 670
+        },
+        {
+          "text": "She turns and points the gun at them. The startle and cower. She smirks then laughs",
+          "timestamp": 691
+        },
+        {
+          "text": "The teens walk down an overgrown, 2 lane road.",
+          "timestamp": 697
+        },
+        {
+          "text": "Dew runs down the tomatoes at the facility",
+          "timestamp": 724
+        },
+        {
+          "text": "She poses",
+          "timestamp": 739
+        },
+        {
+          "text": "A white haired boy opens a door.",
+          "timestamp": 751
+        },
+        {
+          "text": "Mimihime runs away with the blond girl, leaving a black haired boy standing alone, holding a volley ball.",
+          "timestamp": 768
+        },
+        {
+          "text": "He steps up to the overlook and tosses the ball. He hops the railing, drops down from the second floor, runs, jumps, and catches the ball. He approaches the sketching boy, Kona.",
+          "timestamp": 774
+        },
+        {
+          "text": "Mimihime and the blond girl get drinks from a vending machine. They walk across grass. Light from the hexagons overhead stream down between tree leaves.",
+          "timestamp": 785
+        },
+        {
+          "text": "She looks around.",
+          "timestamp": 803
+        },
+        {
+          "text": "They stop at a gray wall",
+          "timestamp": 808
+        },
+        {
+          "text": "At night, the blond girl lies in bed. She sits up, puts on slippers, and walks down the dark hallway, illuminated by a soft strip of light on the floor.",
+          "timestamp": 840
+        },
+        {
+          "text": "She walks into the grass",
+          "timestamp": 852
+        },
+        {
+          "text": "Large, fluffy clouds hover over a pink horizon.",
+          "timestamp": 895
+        },
+        {
+          "text": "Sis drops to her knees on the dirt path.",
+          "timestamp": 906
+        },
+        {
+          "text": "He picks up her bag",
+          "timestamp": 935
+        },
+        {
+          "text": "Mount Fuji towers in the distance. Elsewhere, chickens peck behind wire. Plants grow in rows.",
+          "timestamp": 959
+        },
+        {
+          "text": "A house bears a sign reading Hachisu Ryokan",
+          "timestamp": 964
+        },
+        {
+          "text": "A middle-aged woman holds greens and a sickle in muddy gloves.",
+          "timestamp": 970
+        },
+        {
+          "text": "The woman sits at a desk next to books and a portrait of a young boy.",
+          "timestamp": 999
+        },
+        {
+          "text": "Sis signs the name Kiruko in the log boox. Maru stretches in a green onsen. Inside, Kiruko removes clothes, revealing scars on her butt, back, and shoulders. She sees herself in a cracked mirror. She drops her clothes in a basket and walks towards the mirror. She puts her hand on the glass, and, blushing, leans her lips towards her reflection.",
+          "timestamp": 1043
+        },
+        {
+          "text": "Kiruko gapes at the several dozen colorful bottles.",
+          "timestamp": 1086
+        },
+        {
+          "text": "On the roof, solar panels glimmer in the afternoon sun. Kiruko puts a plug in the wall as the inn keeper passes by",
+          "timestamp": 1090
+        },
+        {
+          "text": "The innkeeper chops vegetables in the kitchen while Maru blow dries Kiruko's hair in the neighboring room. Kiruko glances at a tall bag, propped up against the inkeeper's desk.",
+          "timestamp": 1100
+        },
+        {
+          "text": "She slowly turns to the teens",
+          "timestamp": 1124
+        },
+        {
+          "text": "Her fist clenches around her knife",
+          "timestamp": 1135
+        },
+        {
+          "text": "The innkeeper steps away from the kitchen. The pot boils over, and water flows into the sink.",
+          "timestamp": 1155
+        },
+        {
+          "text": "The innkeeper averts her eyes and turns red.",
+          "timestamp": 1224
+        },
+        {
+          "text": "Maru stares forward",
+          "timestamp": 1246
+        },
+        {
+          "text": "Maru moves his futon",
+          "timestamp": 1255
+        },
+        {
+          "text": "She crawls to him. He faces away, asleep.",
+          "timestamp": 1262
+        },
+        {
+          "text": "She turns off the room light",
+          "timestamp": 1271
+        },
+        {
+          "text": "She crosses the tatami mat room, and stumbles, falling onto her futon, illuminated by the full moon.",
+          "timestamp": 1277
+        },
+        {
+          "text": "She closes her eyes. Clouds drift slowly in the night. Dirty dishes sit in a pile in the sink. The innkeeper unzips her tall bag. Small figurines of dinosaurs sit next to elementary school textbooks and a globe in a dark room.",
+          "timestamp": 1291
+        },
+        {
+          "text": "A large, winged shadow flies over the moon. It descends, landing beyond the windows where the innkeeper sits. Its wingspan fill the double sliding doors.",
+          "timestamp": 1318
+        },
+        {
+          "text": "The monster screams at us, revealing viscous eyes and teeth dotting the cowl of his decapitated neck.",
+          "timestamp": 1341
+        },
+        {
+          "text": "Sliced white text on a black background reads, Heaven and Hell.",
+          "timestamp": 1344
+        },
+        {
+          "text": "Credits roll",
+          "timestamp": 1346
+        },
+        {
+          "text": "Post-episode footnote: Before meeting the bandits, Kiruko consults a map. It includes labels for the Chuo Expressway, the Asari River, and a local train network that splits near the river. The real Chuo Expressway stretches from Tokyo in the east to Nagoya in the west. The Asari River crosses the Expressway at the town of Otsuki, which is a 1.5 hours drive or ride from Tokyo Station. The features of Otskui match the map, including train stations, temples, a country club, and a high school. If driving, Otsuki would be the exit you would take to get to Mount Fuji, about 25km southwest.",
+          "timestamp": 1350
+        }
+      ]
+    }
+  ],
+  "source": {
+    "domain": "disney",
+    "id": "8f515fc0-60ed-4547-b212-47a5630b8500",
+    "url": "https://www.disneyplus.com/play/8f515fc0-60ed-4547-b212-47a5630b8500"
+  }
+}


### PR DESCRIPTION
Adds a synchronized description transcript for Heavenly Delusions S01E01 Heaven and Hell.

Source: https://www.disneyplus.com/play/8f515fc0-60ed-4547-b212-47a5630b8500
File: /transcripts/disney/Heavenly Delusions/S01E01 - Heaven and Hell.json